### PR TITLE
fix: remove unneeded secret

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,6 @@ jobs:
       - uses: GoogleCloudPlatform/release-please-action@v3
         id: release
         with:
-          token: ${{secrets.GITHUB_TOKEN}}
           command: manifest
  
   publish:


### PR DESCRIPTION
This secret doesn't have the right scopes and is preventing release-please from finding the PR, i.e. `RequestError [HttpError]: Error creating Pull Request: Resource not accessible by integration`.